### PR TITLE
Several fixes

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            quay.io/costoolkit/ros-operator
+            quay.io/costoolkit/rancheros-operator
           tags: |
             type=semver,pattern={{raw}}
       - name: Set up Docker Buildx

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -18,7 +18,7 @@ jobs:
           images: |
             quay.io/costoolkit/ros-operator
           tags: |
-            type=semver,pattern=v{{version}}
+            type=semver,pattern={{raw}}
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            quay.io/costoolkit/ros-operator-ci
+            quay.io/costoolkit/rancheros-operator-ci
           tags: |
             type=sha,format=short,prefix=${{ steps.export_tag.outputs.ros_tag }}-
       - name: Set up Docker Buildx

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -10,6 +10,8 @@ concurrency:
 jobs:
   push-docker:
     runs-on: ubuntu-latest
+    outputs:
+      chart_name: ${{ steps.chart.outputs.chart_name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -48,6 +50,11 @@ jobs:
           cache-to: type=gha,mode=max
       - name: Make chart
         run: make chart
+      - name: Set chart output
+        id: chart
+        run: |
+          CHART=$(basename `find . -type f  -name "rancheros-operator*.tgz" -print`)
+          echo "::set-output name=chart_name::$CHART"
       - name: Upload chart
         uses: actions/upload-artifact@v2
         with:
@@ -59,7 +66,7 @@ jobs:
     env:
       VAGRANT_CPU: 3
       VAGRANT_MEMORY: 10240
-      ROS_CHART: ${{ github.workspace }}/build/rancheros-operator-0.0.0-dev.tgz
+      ROS_CHART: ${{ github.workspace }}/build/${{ needs.push-docker.outputs.chart_name }}
     steps:
       - name: Cache Vagrant boxes
         uses: actions/cache@v2

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,37 @@
+project_name: rancheros-operator
+builds:
+  - env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -extldflags -static -s
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 6
+      - 7
+source:
+  enabled: true
+  name_template: '{{ .ProjectName }}-{{ .Tag }}-source'
+archives:
+  # Default template uses underscores instead of -
+  - name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      amd64: x86_64
+checksum:
+  name_template: '{{ .ProjectName }}-{{ .Tag }}-checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^Merge pull request'

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY go.mod go.sum /src/
 RUN go mod download
 COPY main.go /src/
 COPY pkg /src/pkg
-RUN go build -ldflags "-extldflags -static -s" -o /usr/sbin/ros-operator
+RUN go build -ldflags "-extldflags -static -s" -o /usr/sbin/rancheros-operator
 
 FROM scratch as ros-operator
-COPY --from=build /usr/sbin/ros-operator /usr/sbin/ros-operator
+COPY --from=build /usr/sbin/rancheros-operator /usr/sbin/rancheros-operator

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,8 @@ GIT_COMMIT_SHORT?=$(shell git rev-parse --short HEAD)
 GIT_TAG?=$(shell git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.0" )
 TAG?=${GIT_TAG}-${GIT_COMMIT_SHORT}
 REPO?=quay.io/costoolkit/rancheros-operator-ci
-HELM_VERSION?=0.0.0-dev
-export ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-ROS_CHART?=`find $(ROOT_DIR) -type f  -name "rancheros-operator*.tgz" -print`
+ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+ROS_CHART?=$(shell find $(ROOT_DIR) -type f  -name "rancheros-operator*.tgz" -print)
 
 .PHONY: build
 build:
@@ -25,10 +24,9 @@ build-docker-push: build-docker
 chart:
 	mkdir -p  $(ROOT_DIR)/build
 	cp -rf $(ROOT_DIR)/chart $(ROOT_DIR)/build/chart
-	sed -i -e 's/version:.*/version: '${HELM_VERSION}'/' -e 's/appVersion:.*/appVersion: '${TAG}'/' $(ROOT_DIR)/build/chart/Chart.yaml
 	sed -i -e 's/tag:.*/tag: '${TAG}'/' $(ROOT_DIR)/build/chart/values.yaml
 	sed -i -e 's|repository:.*|repository: '${REPO}'|' $(ROOT_DIR)/build/chart/values.yaml
-	helm package -d $(ROOT_DIR)/build/ $(ROOT_DIR)/build/chart
+	helm package --version ${GIT_TAG} --app-version ${GIT_TAG} -d $(ROOT_DIR)/build/ $(ROOT_DIR)/build/chart
 	rm -Rf $(ROOT_DIR)/build/chart
 
 .PHONY: test_deps

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,14 @@ GIT_COMMIT?=$(shell git rev-parse HEAD)
 GIT_COMMIT_SHORT?=$(shell git rev-parse --short HEAD)
 GIT_TAG?=$(shell git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.0" )
 TAG?=${GIT_TAG}-${GIT_COMMIT_SHORT}
-REPO?=quay.io/costoolkit/ros-operator-ci
+REPO?=quay.io/costoolkit/rancheros-operator-ci
 HELM_VERSION?=0.0.0-dev
 export ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 ROS_CHART?=`find $(ROOT_DIR) -type f  -name "rancheros-operator*.tgz" -print`
 
 .PHONY: build
 build:
-	CGO_ENABLED=0 go build -ldflags "-extldflags -static -s" -o build/ros-operator
+	CGO_ENABLED=0 go build -ldflags "-extldflags -static -s" -o build/rancheros-operator
 
 .PHONY: build-docker
 build-docker:

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -32,13 +32,13 @@ spec:
         name: rancheros-operator
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
         command:
-        - /usr/sbin/ros-operator
+        - /usr/sbin/rancheros-operator
       {{- if .Values.hostbin }}
       volumes:
         - name: sbin
           hostPath:
             type: File
-            path: /usr/sbin/ros-operator
+            path: /usr/sbin/rancheros-operator
       {{- end }}
       serviceAccountName: rancheros-operator
       {{- with .Values.tolerations }}


### PR DESCRIPTION
See commits.

With this we fix the docker version to keep the v, set the helm version to a proper name:

```
helm package --version v0.1.0-alpha1 --app-version v0.1.0-alpha1 -d /home/itxaka/projects/rancheros-operator/build/ /home/itxaka/projects/rancheros-operator/build/chart
Successfully packaged chart and saved it to: /home/itxaka/projects/rancheros-operator/build/rancheros-operator-v0.1.0-alpha1.tgz
```

Signed-off-by: Itxaka <igarcia@suse.com>