### PR TITLE
Some kind improvements

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -60,10 +60,14 @@ jobs:
           name: chart
           path: build/*.tgz
   e2e-tests:
+    strategy:
+      matrix:
+        kubernetes: [ "v1.22.7" ]
     runs-on: ubuntu-latest
     needs: push-docker
     env:
       ROS_CHART: ${{ github.workspace }}/build/${{ needs.push-docker.outputs.chart_name }}
+      KUBE_VERSION: ${{ matrix.kubernetes }}
     steps:
       - uses: actions/checkout@v2
       - name: Download chart

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
   push:
     branches:
+      - main
 concurrency:
   group: e2e-tests=full-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ REPO?=quay.io/costoolkit/rancheros-operator-ci
 export ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 ROS_CHART?=$(shell find $(ROOT_DIR) -type f  -name "rancheros-operator*.tgz" -print)
 CHART_VERSION?=$(subst v,,$(GIT_TAG))
+KUBE_VERSION?="v1.22.7"
 
 .PHONY: build
 build:
@@ -40,4 +41,4 @@ unit-tests: test_deps
 	ginkgo -r -v  --covermode=atomic --coverprofile=coverage.out -p -r ./pkg/...
 
 e2e-tests:
-	$(ROOT_DIR)/scripts/e2e-tests.sh
+	KUBE_VERSION=${KUBE_VERSION} $(ROOT_DIR)/scripts/e2e-tests.sh


### PR DESCRIPTION
 - Allow setting different image versions for kubernetes
 - Set a matrix for kubernetes version on CI
 - Use kubectl wait to wait for control panel to be ready
 - Set default kubernetes version to latest rancher ready (v1.22.7)

Signed-off-by: Itxaka <igarcia@suse.com>