### PR TITLE
Fix chart values for release

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -14,9 +14,14 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Build chart
+      - name: Build chart for CI
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         run: |
           make chart
+      - name: Build chart for release
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          REPO=quay.io/costoolkit/rancheros-operator TAG=${GITHUB_REF##*/} make chart
       - name: Publish chart to release
         uses: fnkr/github-action-ghr@v1
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
We were missing setting the proper repo and short tag on tag release and
were instead leaving the default values in there which made our released
chart point to the ci values with ci images

Instead point ot the proper repo and set the image tag of the chart to
the released tagged image (no commit or anything in the image)

Signed-off-by: Itxaka <igarcia@suse.com>