### PR TITLE
various fixes and add e2e upgrades tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.18.1
 	github.com/pkg/errors v0.9.1
-	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220407145032-98e4e6e3302b
+	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220420071633-4d090487a09f
 	github.com/rancher-sandbox/go-tpm v0.0.0-20220217133323-a7b15ad1f8f7
 	github.com/rancher/fleet/pkg/apis v0.0.0-20210927195558-4aaa778d23dd
 	github.com/rancher/lasso v0.0.0-20210709145333-6c6cd7fd6607

--- a/go.sum
+++ b/go.sum
@@ -945,6 +945,8 @@ github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4do
 github.com/rackspace/gophercloud v0.0.0-20150408191457-ce0f487f6747/go.mod h1:4bJ1FwuaBZ6dt1VcDX5/O662mwR8GWqS4l68H6hkoYQ=
 github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220407145032-98e4e6e3302b h1:Qiuk6Mac457YLNgvlW2dAa5LWxMKWVYihouqDXessZk=
 github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220407145032-98e4e6e3302b/go.mod h1:tBG6E0pF89pslQvva2lKhL/6ShpqAkjwFhdUfevTR6o=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220420071633-4d090487a09f h1:uK8GhwkyGVreyMlgG4eMesj6Iz0eIyLVpRmB6SJjPMA=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220420071633-4d090487a09f/go.mod h1:bbNiiDprIZSIzNmWvyQ+ro6N39bnyNiEGdgiD9vAQM0=
 github.com/rancher-sandbox/go-tpm v0.0.0-20220217133323-a7b15ad1f8f7 h1:+Yq4bfEJBV35QFNQFhvRsjwOIfxU0SAPZDCefAM8jy4=
 github.com/rancher-sandbox/go-tpm v0.0.0-20220217133323-a7b15ad1f8f7/go.mod h1:cUw+h4wm01VdavMOjUMVQ5m/b2oiOjZ7gweI8AlybO4=
 github.com/rancher/aks-operator v1.0.2 h1:R6niUq/IlhzKpzRFmRR9YMiMePJh1flEqFO86us7OMY=

--- a/pkg/controllers/managedos/managedos.go
+++ b/pkg/controllers/managedos/managedos.go
@@ -85,7 +85,6 @@ func (h *handler) OnChange(mos *provv1.ManagedOSImage, status provv1.ManagedOSIm
 	if mos.Spec.OSImage == "" && mos.Spec.ManagedOSVersionName == "" {
 		return nil, status, nil
 	}
-
 	prefix, err := h.defaultRegistry()
 	if err != nil {
 		return nil, status, err

--- a/pkg/controllers/managedos/template.go
+++ b/pkg/controllers/managedos/template.go
@@ -171,11 +171,18 @@ func (h *handler) objects(mos *osv1.ManagedOSImage, prefix string) ([]runtime.Ob
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "os-upgrader",
 			},
-			Rules: []rbacv1.PolicyRule{{
-				Verbs:     []string{"update", "get", "list", "watch", "patch"},
-				APIGroups: []string{""},
-				Resources: []string{"nodes"},
-			}},
+			Rules: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"update", "get", "list", "watch", "patch"},
+					APIGroups: []string{""},
+					Resources: []string{"nodes"},
+				},
+				{
+					Verbs:     []string{"list"},
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+				},
+			},
 		},
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/managedos/template.go
+++ b/pkg/controllers/managedos/template.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
-	"github.com/sirupsen/logrus"
 
 	osv1 "github.com/rancher-sandbox/rancheros-operator/pkg/apis/rancheros.cattle.io/v1"
 	"github.com/rancher-sandbox/rancheros-operator/pkg/clients"

--- a/pkg/controllers/managedos/template.go
+++ b/pkg/controllers/managedos/template.go
@@ -19,9 +19,11 @@ package managedos
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	"github.com/sirupsen/logrus"
 
 	osv1 "github.com/rancher-sandbox/rancheros-operator/pkg/apis/rancheros.cattle.io/v1"
 	"github.com/rancher-sandbox/rancheros-operator/pkg/clients"
@@ -155,6 +157,13 @@ func (h *handler) objects(mos *osv1.ManagedOSImage, prefix string) ([]runtime.Ob
 			metadataEnv = append(metadataEnv, e)
 		}
 	}
+
+	sort.Slice(metadataEnv, func(i, j int) bool {
+		dat := []string{metadataEnv[i].Name, metadataEnv[j].Name}
+		sort.Strings(dat)
+		return dat[0] == metadataEnv[i].Name
+	})
+
 	upgradeContainerSpec.Env = metadataEnv
 
 	return []runtime.Object{

--- a/tests/catalog/managedosimage.go
+++ b/tests/catalog/managedosimage.go
@@ -16,13 +16,30 @@ limitations under the License.
 
 package catalog
 
+import (
+	"time"
+)
+
+type DrainSpec struct {
+	Timeout                  *time.Duration `json:"timeout,omitempty" yaml:"timeout"`
+	GracePeriod              *int32         `json:"gracePeriod,omitempty" yaml:"gracePeriod"`
+	DeleteLocalData          *bool          `json:"deleteLocalData,omitempty" yaml:"deleteLocalData"`
+	IgnoreDaemonSets         *bool          `json:"ignoreDaemonSets,omitempty" yaml:"ignoreDaemonSets"`
+	Force                    bool           `json:"force,omitempty" yaml:"force"`
+	DisableEviction          bool           `json:"disableEviction,omitempty" yaml:"disableEviction"`
+	SkipWaitForDeleteTimeout int            `json:"skipWaitForDeleteTimeout,omitempty" yaml:"skipWaitForDeleteTimeout"`
+}
+
 type ManagedOSImage struct {
 	APIVersion string `json:"apiVersion" yaml:"apiVersion"`
 	Kind       string `json:"kind" yaml:"kind"`
 	Metadata   struct {
 		Name string `json:"name" yaml:"name"`
 	} `json:"metadata" yaml:"metadata"`
+
 	Spec struct {
+		Cordon               *bool                    `json:"cordon,omitempty" yaml:"cordon"`
+		Drain                *DrainSpec               `json:"drain,omitempty" yaml:"drain"`
 		OSImage              string                   `json:"osImage" yaml:"osImage"`
 		ManagedOSVersionName string                   `json:"managedOSVersionName" yaml:"managedOSVersionName"`
 		ClusterTargets       []map[string]interface{} `json:"clusterTargets" yaml:"clusterTargets"`
@@ -30,6 +47,8 @@ type ManagedOSImage struct {
 }
 
 func NewManagedOSImage(name string, clusterTargets []map[string]interface{}, mosImage string, mosVersionName string) *ManagedOSImage {
+	cordon := false
+
 	return &ManagedOSImage{
 		APIVersion: "rancheros.cattle.io/v1",
 		Metadata: struct {
@@ -37,13 +56,38 @@ func NewManagedOSImage(name string, clusterTargets []map[string]interface{}, mos
 		}{Name: name},
 		Kind: "ManagedOSImage",
 		Spec: struct {
-			OSImage              string                   "json:\"osImage\" yaml:\"osImage\""
-			ManagedOSVersionName string                   "json:\"managedOSVersionName\" yaml:\"managedOSVersionName\""
-			ClusterTargets       []map[string]interface{} "json:\"clusterTargets\" yaml:\"clusterTargets\""
+			Cordon               *bool                    `json:"cordon,omitempty" yaml:"cordon"`
+			Drain                *DrainSpec               `json:"drain,omitempty" yaml:"drain"`
+			OSImage              string                   `json:"osImage" yaml:"osImage"`
+			ManagedOSVersionName string                   `json:"managedOSVersionName" yaml:"managedOSVersionName"`
+			ClusterTargets       []map[string]interface{} `json:"clusterTargets" yaml:"clusterTargets"`
 		}{
 			OSImage:              mosImage,
 			ManagedOSVersionName: mosVersionName,
+			Cordon:               &cordon,
 			ClusterTargets:       clusterTargets,
+		},
+	}
+}
+
+func DrainOSImage(name string, managedOSVersion string, drainSpec *DrainSpec) *ManagedOSImage {
+	cordon := false
+	return &ManagedOSImage{
+		APIVersion: "rancheros.cattle.io/v1",
+		Metadata: struct {
+			Name string "json:\"name\" yaml:\"name\""
+		}{Name: name},
+		Kind: "ManagedOSImage",
+		Spec: struct {
+			Cordon               *bool                    `json:"cordon,omitempty" yaml:"cordon"`
+			Drain                *DrainSpec               `json:"drain,omitempty" yaml:"drain"`
+			OSImage              string                   `json:"osImage" yaml:"osImage"`
+			ManagedOSVersionName string                   `json:"managedOSVersionName" yaml:"managedOSVersionName"`
+			ClusterTargets       []map[string]interface{} `json:"clusterTargets" yaml:"clusterTargets"`
+		}{
+			Cordon:               &cordon,
+			ManagedOSVersionName: managedOSVersion,
+			Drain:                drainSpec,
 		},
 	}
 }

--- a/tests/catalog/managedosversion.go
+++ b/tests/catalog/managedosversion.go
@@ -35,7 +35,7 @@ type ManagedOSVersion struct {
 
 type ContainerSpec struct {
 	Image   string   `json:"image,omitempty" yaml:"image,omitempty"`
-	Command string   `json:"command,omitempty" yaml:"command,omitempty"`
+	Command []string `json:"command,omitempty" yaml:"command,omitempty"`
 	Args    []string `json:"args,omitempty" yaml:"args,omitempty"`
 }
 

--- a/tests/catalog/managedosversionchannel.go
+++ b/tests/catalog/managedosversionchannel.go
@@ -19,7 +19,7 @@ package catalog
 type ManagedOSVersionChannelSpec struct {
 	Type             string                 `json:"type" yaml:"type"`
 	Options          map[string]interface{} `json:"options" yaml:"options"`
-	UpgradeContainer ContainerSpec          `json:"upgradeContainer" yaml:"upgradeContainer"`
+	UpgradeContainer *ContainerSpec         `json:"upgradeContainer,omitempty" yaml:"upgradeContainer"`
 }
 
 type ManagedOSVersionChannel struct {
@@ -31,7 +31,7 @@ type ManagedOSVersionChannel struct {
 	Spec ManagedOSVersionChannelSpec
 }
 
-func NewManagedOSVersionChannel(name string, t string, options map[string]interface{}) *ManagedOSVersionChannel {
+func NewManagedOSVersionChannel(name string, t string, options map[string]interface{}, upgradeContainer *ContainerSpec) *ManagedOSVersionChannel {
 	return &ManagedOSVersionChannel{
 		APIVersion: "rancheros.cattle.io/v1",
 		Metadata: struct {
@@ -39,8 +39,9 @@ func NewManagedOSVersionChannel(name string, t string, options map[string]interf
 		}{Name: name},
 		Kind: "ManagedOSVersionChannel",
 		Spec: ManagedOSVersionChannelSpec{
-			Type:    t,
-			Options: options,
+			Type:             t,
+			Options:          options,
+			UpgradeContainer: upgradeContainer,
 		},
 	}
 }

--- a/tests/e2e/managedosversionchannel_test.go
+++ b/tests/e2e/managedosversionchannel_test.go
@@ -37,6 +37,11 @@ import (
 var _ = Describe("ManagedOSVersionChannel e2e tests", func() {
 	var k *kubectl.Kubectl
 
+	AfterEach(func() {
+		err := k.Delete("managedosversionchannel", "--all", "--force", "--wait", "-n", "fleet-default")
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
 	Context("Create ManagedOSVersions", func() {
 		BeforeEach(func() {
 			k = kubectl.New()
@@ -48,6 +53,7 @@ var _ = Describe("ManagedOSVersionChannel e2e tests", func() {
 				"invalid",
 				"",
 				map[string]interface{}{"uri": "http://" + bridgeIP + ":9999"},
+				nil,
 			)
 
 			err := k.ApplyYAML("fleet-default", "invalid", ui)
@@ -109,6 +115,7 @@ var _ = Describe("ManagedOSVersionChannel e2e tests", func() {
 				"testchannel",
 				"json",
 				map[string]interface{}{"uri": "http://" + bridgeIP + ":9999"},
+				nil,
 			)
 
 			err = k.ApplyYAML("fleet-default", "testchannel", ui)
@@ -204,6 +211,7 @@ var _ = Describe("ManagedOSVersionChannel e2e tests", func() {
 					"outputFile": "/output/data", // This defaults to /data/output
 					"args":       []string{fmt.Sprintf("echo '%s' > /output/data", string(b))},
 				},
+				nil,
 			)
 
 			err = k.ApplyYAML("fleet-default", "testchannel2", ui)

--- a/tests/e2e/upgrades_test.go
+++ b/tests/e2e/upgrades_test.go
@@ -1,0 +1,396 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	kubectl "github.com/rancher-sandbox/ele-testhelpers/kubectl"
+	upgradev1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
+
+	"github.com/rancher-sandbox/rancheros-operator/tests/catalog"
+)
+
+const cattleNamespace = "cattle-system"
+const fleetNamespace = "fleet-local"
+const discoveryPluginImage = "quay.io/costoolkit/upgradechannel-discovery:v0.3-4b83dbe"
+
+func getPlan(s string) (up *upgradev1.Plan, err error) {
+	up = &upgradev1.Plan{}
+	r, err := kubectl.GetData(cattleNamespace, "plan", s, `jsonpath={}`)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	err = json.Unmarshal(r, up)
+	return
+}
+
+func getPod(s string) (up *corev1.Pod, err error) {
+	up = &corev1.Pod{}
+	r, err := kubectl.GetData(cattleNamespace, "pods", s, `jsonpath={}`)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	err = json.Unmarshal(r, up)
+	return
+}
+
+func waitTestChannelPopulate(k *kubectl.Kubectl, mr *catalog.ManagedOSVersionChannel, name string, image, version string) {
+	EventuallyWithOffset(1, func() error {
+		return k.ApplyYAML(fleetNamespace, name, mr)
+	}, 2*time.Minute, 2*time.Second).ShouldNot(HaveOccurred())
+
+	EventuallyWithOffset(1, func() string {
+		r, err := kubectl.GetData(fleetNamespace, "ManagedOSVersion", version, `jsonpath={.spec.metadata.upgradeImage}`)
+		if err != nil {
+			fmt.Println(err)
+		}
+		return string(r)
+	}, 6*time.Minute, 2*time.Second).Should(
+		Equal(image),
+	)
+}
+
+func upgradePod(k *kubectl.Kubectl) string {
+	pods, err := k.GetPodNames(cattleNamespace, "upgrade.cattle.io/controller=system-upgrade-controller")
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	podName := ""
+	for _, p := range pods {
+		if strings.Contains(p, "apply-os-upgrader") {
+			podName = p
+		}
+	}
+	return podName
+}
+
+func checkUpgradePod(k *kubectl.Kubectl, env, image, command, args, mm types.GomegaMatcher) {
+	waitUpgradePod(k)
+	podName := upgradePod(k)
+
+	pod, err := getPod(podName)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	container := pod.Spec.Containers[0]
+
+	envs := []string{}
+	for _, e := range container.Env {
+		envs = append(envs, fmt.Sprintf("%s=%s", e.Name, e.Value))
+	}
+	mounts := []string{}
+	for _, e := range container.VolumeMounts {
+		mounts = append(mounts, fmt.Sprintf("%s=%s", e.Name, e.MountPath))
+	}
+	ExpectWithOffset(1, container.Name).To(Equal("upgrade"))
+	ExpectWithOffset(1, envs).To(env)
+	ExpectWithOffset(1, container.Image).To(image)
+	ExpectWithOffset(1, container.Command).To(command)
+	ExpectWithOffset(1, container.Args).To(args)
+	ExpectWithOffset(1, mounts).To(mm)
+}
+
+func waitUpgradePod(k *kubectl.Kubectl) {
+	EventuallyWithOffset(1, func() []string {
+		pods, err := k.GetPodNames(cattleNamespace, "upgrade.cattle.io/controller=system-upgrade-controller")
+		if err != nil {
+			fmt.Println(err)
+		}
+		return pods
+	}, 3*time.Minute, 2*time.Second).Should(ContainElement(ContainSubstring("apply-os-upgrader-on-ros-e2e-control-plane-with")))
+}
+
+var _ = Describe("ManagedOSImage e2e tests", func() {
+	k := kubectl.New()
+
+	Context("Using ManagedOSVersion reference", func() {
+		osImage := "update-osversion"
+		osVersion := "osversion"
+		AfterEach(func() {
+			k.Delete("managedosimage", "-n", fleetNamespace, osImage)
+			k.Delete("managedosversion", "-n", fleetNamespace, osVersion)
+
+			// Plans do not successfully apply, so nodes stays in cordoned state.
+			// uncordon them so tests will keep running
+			nodeName, err := kubectl.Run("get", "nodes", "-o", "jsonpath='{.items[0].metadata.name}'")
+			Expect(err).ToNot(HaveOccurred())
+			kubectl.Run("uncordon", nodeName)
+
+			k.Delete("jobs", "--all", "--wait", "-n", fleetNamespace)
+			k.Delete("plans", "--all", "--wait", "-n", fleetNamespace)
+			k.Delete("bundles", "--all", "--wait", "-n", fleetNamespace)
+			k.Delete("managedosversionchannel", "--all", "--wait", "-n", fleetNamespace)
+
+			// delete dangling upgrade pods
+			EventuallyWithOffset(1, func() []string {
+				pods, err := k.GetPodNames(cattleNamespace, "upgrade.cattle.io/controller=system-upgrade-controller")
+				if err != nil {
+					fmt.Println(err)
+				}
+				fmt.Println(pods)
+
+				applyPods := []string{}
+				for _, p := range pods {
+					if !strings.HasPrefix(p, "system-upgrade-controller") {
+						applyPods = append(applyPods, p)
+					}
+
+					if strings.Contains(p, "apply-os-upgrader") {
+						By("deleting " + p)
+						k.Delete("pod", "-n", cattleNamespace, "--wait", "--force", p)
+						err = k.WaitForPodDelete(cattleNamespace, p)
+						Expect(err).ToNot(HaveOccurred())
+					}
+				}
+
+				return applyPods
+			}, 3*time.Minute, 2*time.Second).Should(Equal([]string{}))
+		})
+
+		createsCorrectPlan := func(meta map[string]interface{}, c *catalog.ContainerSpec, m types.GomegaMatcher) {
+			ov := catalog.NewManagedOSVersion(
+				osVersion, "v1.0", "0.0.0",
+				meta,
+				c,
+			)
+
+			EventuallyWithOffset(1, func() error {
+				return k.ApplyYAML(fleetNamespace, osVersion, ov)
+			}, 2*time.Minute, 2*time.Second).ShouldNot(HaveOccurred())
+
+			ui := catalog.NewManagedOSImage(
+				osImage,
+				[]map[string]interface{}{},
+				"",
+				osVersion,
+			)
+
+			EventuallyWithOffset(1, func() error {
+				return k.ApplyYAML(fleetNamespace, osImage, ui)
+			}, 2*time.Minute, 2*time.Second).ShouldNot(HaveOccurred())
+
+			EventuallyWithOffset(1, func() string {
+				r, err := kubectl.GetData(fleetNamespace, "bundle", "mos-update-osversion", `jsonpath={.spec.resources[*].content}`)
+				if err != nil {
+					fmt.Println(err)
+				}
+				return string(r)
+			}, 1*time.Minute, 2*time.Second).Should(
+				m,
+			)
+		}
+
+		It("tries to apply a plan", func() {
+			By("creating a new ManagedOSImage referencing a ManagedOSVersion")
+
+			createsCorrectPlan(map[string]interface{}{"upgradeImage": "registry.com/repository/image:v1.0", "robin": "batman"}, nil,
+				And(
+					ContainSubstring(`"version":"v1.0"`),
+					ContainSubstring(`"image":"registry.com/repository/image"`),
+					ContainSubstring(`"command":["/usr/sbin/suc-upgrade"]`),
+					ContainSubstring(`"name":"METADATA_ROBIN","value":"batman"`),
+				),
+			)
+
+			Eventually(func() string {
+				up, err := getPlan("os-upgrader")
+				if err == nil {
+					return up.Spec.Version
+				} else {
+					fmt.Println(err)
+				}
+				return ""
+			}, 1*time.Minute, 2*time.Second).Should(Equal("v1.0"))
+
+			plan, err := getPlan("os-upgrader")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(plan.Spec.Upgrade.Image).To(Equal("registry.com/repository/image"))
+
+			checkUpgradePod(k,
+				And(
+					ContainElement("METADATA_ROBIN=batman"),
+					ContainElement("METADATA_UPGRADEIMAGE=registry.com/repository/image:v1.0"),
+				),
+				Equal("registry.com/repository/image:v1.0"),
+				Equal([]string{"/usr/sbin/suc-upgrade"}),
+				BeNil(),
+				And(
+					ContainElement("host-root=/host"),
+				),
+			)
+		})
+
+		It("applies an os-upgrade from a channel", func() {
+			mr := catalog.NewManagedOSVersionChannel(
+				"testchannel3",
+				"custom",
+				map[string]interface{}{
+					"image": discoveryPluginImage,
+					"envs": []map[string]string{
+						{
+							"name":  "REPOSITORY",
+							"value": "https://github.com/rancher-sandbox/upgradechannel-discovery-test-repo",
+						},
+					},
+					"command": []string{"/usr/bin/upgradechannel-discovery"},
+					"args":    []string{"git"},
+				},
+				nil,
+			)
+			defer k.Delete("managedosversionchannel", "-n", fleetNamespace, "testchannel3")
+
+			waitTestChannelPopulate(k, mr, "testchannel3", "foo/bar:v0.1.0-beta1", "v0.1.0-beta1")
+
+			err := k.ApplyYAML(fleetNamespace, osImage, catalog.NewManagedOSImage(
+				osImage,
+				[]map[string]interface{}{},
+				"",
+				"v0.1.0-beta1",
+			))
+			Expect(err).ToNot(HaveOccurred())
+
+			checkUpgradePod(k,
+				And(
+					ContainElement("METADATA_UPGRADEIMAGE=foo/bar:v0.1.0-beta1"),
+				),
+				Equal("foo/bar:v0.1.0-beta1"),
+				Equal([]string{"/usr/sbin/suc-upgrade"}),
+				BeNil(),
+				And(
+					ContainElement("host-root=/host"),
+				),
+			)
+		})
+
+		It("overwrites default container spec from a channel", func() {
+			mr := catalog.NewManagedOSVersionChannel(
+				"testchannel4",
+				"custom",
+				map[string]interface{}{
+					"image": discoveryPluginImage,
+					"envs": []map[string]string{
+						{
+							"name":  "REPOSITORY",
+							"value": "https://github.com/rancher-sandbox/upgradechannel-discovery-test-repo",
+						},
+					},
+					"command": []string{"/usr/bin/upgradechannel-discovery"},
+					"args":    []string{"git"},
+				},
+				&catalog.ContainerSpec{
+					Image:   "Foobarz",
+					Command: []string{"foo"},
+					Args:    []string{"baz"},
+				},
+			)
+			defer k.Delete("managedosversionchannel", "-n", fleetNamespace, "testchannel4")
+
+			waitTestChannelPopulate(k, mr, "testchannel4", "foo/bar:v0.1.0-beta1", "v0.1.0-beta1")
+
+			err := k.ApplyYAML(fleetNamespace, osImage, catalog.NewManagedOSImage(
+				osImage,
+				[]map[string]interface{}{},
+				"",
+				"v0.1.0-beta1",
+			))
+			Expect(err).ToNot(HaveOccurred())
+
+			checkUpgradePod(k,
+				And(
+					ContainElement("METADATA_UPGRADEIMAGE=foo/bar:v0.1.0-beta1"),
+				),
+				Equal("Foobarz"),
+				Equal([]string{"foo"}),
+				Equal([]string{"baz"}),
+				And(
+					ContainElement("host-root=/host"),
+				),
+			)
+		})
+
+		It("tries to apply an upgrade", func() {
+			mr := catalog.NewManagedOSVersionChannel(
+				"testchannel5",
+				"custom",
+				map[string]interface{}{
+					"image": discoveryPluginImage,
+					"envs": []map[string]string{
+						{
+							"name":  "REPOSITORY",
+							"value": "rancher-sandbox/os2",
+						},
+						{
+							"name":  "REPOSITORY",
+							"value": "rancher-sandbox/os2",
+						},
+						{
+							"name":  "IMAGE_PREFIX",
+							"value": "quay.io/costoolkit/os2",
+						},
+						{
+							"name":  "VERSION_SUFFIX",
+							"value": "-amd64",
+						},
+					},
+					"command": []string{"/usr/bin/upgradechannel-discovery"},
+					"args":    []string{"github"},
+				},
+				nil,
+			)
+			defer k.Delete("managedosversionchannel", "-n", fleetNamespace, "testchannel5")
+
+			waitTestChannelPopulate(k, mr, "testchannel5", "quay.io/costoolkit/os2:v0.1.0-alpha22-amd64", "v0.1.0-alpha22-amd64")
+
+			err := k.ApplyYAML(fleetNamespace, osImage,
+				catalog.NewManagedOSImage(osImage, []map[string]interface{}{}, "", "v0.1.0-alpha22-amd64"))
+			Expect(err).ToNot(HaveOccurred())
+
+			checkUpgradePod(k,
+				And(
+					ContainElement("METADATA_UPGRADEIMAGE=quay.io/costoolkit/os2:v0.1.0-alpha22-amd64"),
+				),
+				Equal("quay.io/costoolkit/os2:v0.1.0-alpha22-amd64"),
+				Equal([]string{"/usr/sbin/suc-upgrade"}),
+				BeNil(),
+				And(
+					ContainElement("host-root=/host"),
+				),
+			)
+
+			Eventually(func() string {
+				podName := upgradePod(k)
+				str, _ := kubectl.Run("logs", "-n", cattleNamespace, podName)
+				fmt.Println(str)
+				return str
+			}, 5*time.Minute, 2*time.Second).Should(
+				And(
+					ContainSubstring("Starting elemental version"),
+					ContainSubstring("Could not find device for COS_RECOVERY label: no device found"),
+				))
+		})
+	})
+})


### PR DESCRIPTION
Fixes: https://github.com/rancher-sandbox/os2/issues/86
Part of https://github.com/rancher-sandbox/os2/issues/87 as includes custom syncer tests. Currently the suite imports a channel and tries to trigger an upgrade for it. It inspects the plan and that a pod which will run the upgrade starts in the cluster.

It includes also fixes found while doing tests which pushed multiple times the same env in the pod spec,  https://github.com/rancher-sandbox/rancheros-operator/pull/28/commits/903ccf6cfe11dabf7ba57d3bf9f6aa6ac959f340 